### PR TITLE
 Update SolidRun RZ/G2LC HummingBoard 

### DIFF
--- a/meta-rz-bsp/conf/machine/solidrun-rzg2lc-hummingboard.conf
+++ b/meta-rz-bsp/conf/machine/solidrun-rzg2lc-hummingboard.conf
@@ -5,11 +5,22 @@
 require include/rzg2l-family.inc
 
 # Linux kernel configuration
-PREFERRED_PROVIDER_virtual/kernel = "linux-solidrun"
-PREFERRED_VERSION_linux-solidrun  = "5.10.%"
+PREFERRED_PROVIDER_virtual/kernel = "linux-stable"
+PREFERRED_VERSION_linux-solidrun  = "6.9.%"
 KERNEL_DEVICETREE_BASENAME = "rzg2lc-hummingboard"
 KBUILD_DEFCONFIG = "rz-solidrun_defconfig"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "linux-firmware-bcm43439"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+        linux-firmware-bcm43439 linux-firmware-bcm-0bb4-0306 \
+        kernel-module-brcmfmac kernel-module-brcmfmac-cyw \
+        kernel-module-btbcm \
+"
+
+KERNEL_DEVICETREE:append = " \
+        renesas/rzg2lc-solidrun-sd-overlay.dtbo \
+        renesas/rzg2lc-solidrun-mmc-overlay.dtbo \
+"
+
+KERNEL_DTC_FLAGS:append = " -@"
 
 # U-Boot configuration
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-solidrun"

--- a/meta-rz-bsp/recipes-bsp/u-boot/u-boot-solidrun/0001-Use-boot-as-default-overlay-location.patch
+++ b/meta-rz-bsp/recipes-bsp/u-boot/u-boot-solidrun/0001-Use-boot-as-default-overlay-location.patch
@@ -1,0 +1,25 @@
+From 9c1624944f26605c6d89f77bb54d7d8d0670e940 Mon Sep 17 00:00:00 2001
+From: Mikhail Anikin <mikhail.anikin@solid-run.com>
+Date: Tue, 8 Oct 2024 13:24:02 +0300
+Subject: [PATCH] Use boot as default overlay location
+
+---
+ include/configs/rzg2l-solidrun-common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/rzg2l-solidrun-common.h b/include/configs/rzg2l-solidrun-common.h
+index e973644a4a..01b09e1144 100644
+--- a/include/configs/rzg2l-solidrun-common.h
++++ b/include/configs/rzg2l-solidrun-common.h
+@@ -97,7 +97,7 @@
+     "kernel_comp_addr_r=" KERNEL_COMP_ADDR_R "\0" \
+     "kernel_comp_size=" KERNEL_COMP_SIZE "\0" \
+     "fdt_buffer_size=" FDT_BUFFER_SIZE "\0" \
+-    "fdtoverlay_dir=/renesas\0" \
++    "fdtoverlay_dir=/boot\0" \
+     "fdtoverlay_mmc_filename=" SR_MMC_BOOT_OVERLAY "\0" \
+     "fdtoverlay_sd_filename=" SR_SD_BOOT_OVERLAY "\0" \
+     "sdio_toggle=gpio toggle gpio-221; gpio toggle gpio-390; mmc rescan 1\0" \
+-- 
+2.46.2
+

--- a/meta-rz-bsp/recipes-bsp/u-boot/u-boot-solidrun_2021.10.bb
+++ b/meta-rz-bsp/recipes-bsp/u-boot/u-boot-solidrun_2021.10.bb
@@ -2,8 +2,12 @@ require u-boot-renesas.inc
 
 COMPATIBLE_MACHINE = "(rzg2h-family|rzg2l-family)"
 
-SRCREV = "a230e5df53a34de412a4defed1b3c430b2c4cceb"
-BRANCH = "v2021.10/rz-sr"
+SRCREV = "428d62406882493af7cfe510676dd14f4554ad40"
+BRANCH = "v2021.10/rz-sr-cip41"
 UBOOT_URL = "git://github.com/SolidRun/u-boot.git"
 
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+
+SRC_URI:append = " \
+    file://0001-Use-boot-as-default-overlay-location.patch \
+"

--- a/meta-rz-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-rz-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -9,6 +9,10 @@ do_install:append() {
     install -d ${D}${nonarch_base_libdir}/firmware
     cp -r ${WORKDIR}/firmware/* ${D}${nonarch_base_libdir}/firmware
     cp -r ${WORKDIR}/LICENSE ${D}${nonarch_base_libdir}/firmware/brcm
+    cd ${D}${nonarch_base_libdir}/firmware/brcm
+    ln -s brcmfmac43439-sdio.bin brcmfmac43439-sdio.renesas,rzg2lc-sr-som.bin
+    ln -s brcmfmac43439-sdio.txt brcmfmac43439-sdio.renesas,rzg2lc-sr-som.txt
+    ln -s brcmfmac43439-sdio.clm_blob brcmfmac43439-sdio.renesas,rzg2lc-sr-som.clm_blob
 }
 
 PACKAGES =+ "${PN}-bcm43439"
@@ -20,3 +24,4 @@ FILES:${PN}-bcm43439 += " \
     ${nonarch_base_libdir}/firmware/brcm/*43439* \
     ${nonarch_base_libdir}/firmware/cypress/*43439* \
 "
+FILES:${PN}-bcm-0bb4-0306 += "${nonarch_base_libdir}/firmware/brcm/BCM.hcd"

--- a/meta-rz-bsp/recipes-kernel/linux/linux-stable/0001-arm64-dts-renesas-Cleanup-HummingBoard-RZG2LC-Device.patch
+++ b/meta-rz-bsp/recipes-kernel/linux/linux-stable/0001-arm64-dts-renesas-Cleanup-HummingBoard-RZG2LC-Device.patch
@@ -1,0 +1,577 @@
+From 3a7cb370c5335aec16d0fb9e10da48f83caa2157 Mon Sep 17 00:00:00 2001
+From: Mikhail Anikin <mikhail.anikin@solid-run.com>
+Date: Tue, 8 Oct 2024 18:04:01 +0300
+Subject: [PATCH 1/3] arm64: dts: renesas: Cleanup HummingBoard RZG2LC Device
+ tree
+
+This commit streamlines the device tree for the Renesas RZ/G2LC HummingBoard by making the following changes:
+
+- **Remove eMMC support**: Eliminate conditional code based on `SW_SD0_DEV_SEL`
+
+- **Enable HDMI interrupts**: Update the `adv7535` HDMI transmitter node by enabling interrupts
+
+- **Adjust SDHI0 configurations**: Modify SDHI0 pin settings and regulators to reflect simplified eMMC support
+
+- **Rename clock nodes for clarity**: Change `x1_clk` to `xin24m-clock` and `x2_clk` to `xin32k-clock` to better represent their functions and improve readability.
+
+- **Update Bluetooth node**: Correct the compatible string in the Bluetooth node to `"brcm,bcm43438-bt"`
+
+- **Add memory region to GPU node**: Include `memory-region = <&multimedia_cma>;` in the GPU node to define the reserved memory for GPU u
+---
+ .../dts/renesas/rz-hummingboard-common.dtsi   | 72 ++--------------
+ .../dts/renesas/rz_2l-sr-pinfunction.dtsi     | 83 +++++++++++--------
+ .../boot/dts/renesas/rz_2l-sr-som-common.dtsi | 29 +++----
+ .../boot/dts/renesas/rzg2lc-hummingboard.dts  | 19 +----
+ .../arm64/boot/dts/renesas/rzg2lc-sr-som.dtsi | 65 ++++++---------
+ 5 files changed, 95 insertions(+), 173 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/renesas/rz-hummingboard-common.dtsi b/arch/arm64/boot/dts/renesas/rz-hummingboard-common.dtsi
+index bf84d960d50d..5a5306d75c01 100644
+--- a/arch/arm64/boot/dts/renesas/rz-hummingboard-common.dtsi
++++ b/arch/arm64/boot/dts/renesas/rz-hummingboard-common.dtsi
+@@ -44,15 +44,6 @@ cam_ext_1v2: 1p2v {
+ 		regulator-always-on;
+ 	};
+ 
+-	reg_sdhi0_vmmc: regulator-sdhi0 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "VSD_3V3";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&pinctrl RZG2L_GPIO(4, 1) GPIO_ACTIVE_LOW>;
+-		regulator-always-on;
+-	};
+-
+ 	usb0_vbus_otg: regulator-usb0-vbus-otg {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "USB0_VBUS_OTG";
+@@ -75,12 +66,6 @@ usb1_vbus: regulator-usb1-vbus {
+ 		enable-active-high;
+ 	};
+ 
+-	imx219_clk: osc25250_clk {
+-		compatible = "fixed-clock";
+-		#clock-cells = <0>;
+-		clock-frequency = <24000000>;
+-	};
+-
+ 	ar0521_clk: osc27000_clk {
+ 		compatible = "fixed-clock";
+ 		#clock-cells = <0>;
+@@ -146,10 +131,12 @@ &du {
+ };
+ 
+ &ehci0 {
++	spurious-oc;
+ 	status = "okay";
+ };
+ 
+ &ehci1 {
++	spurious-oc;
+ 	status = "okay";
+ };
+ 
+@@ -172,14 +159,8 @@ adv7535: adv7535@3d {
+ 		reg = <0x3d>;
+ 		adi,dsi-lanes = <4>;
+ 		pd-gpios = <&pinctrl RZG2L_GPIO(3, 0) GPIO_ACTIVE_LOW>; // ADV_PD / DSI_EN J9-34 / P4_0
+-		/*
+-		 * With interrupts enabled and hdmi connected during boot,
+-		 * rzg2l_mipi_dsi_enable never happens and display receives no signal.
+-		 * Re-enable once issue has been resolved.
+-		 *
+-		 * interrupt-parent = <&pinctrl>;
+-		 * interrupts = <RZG2L_GPIO(9, 1) IRQ_TYPE_EDGE_FALLING>; // DSI_TS_nINT J5001-43 P9_1
+-		 */
++		interrupt-parent = <&pinctrl>;
++		interrupts = <RZG2L_GPIO(9, 1) IRQ_TYPE_EDGE_FALLING>;// DSI_TS_nINT J5001-43 P9_1
+ 		avdd-supply = <&reg_1p8v>;
+ 		dvdd-supply = <&reg_1p8v>;
+ 		pvdd-supply = <&reg_1p8v>;
+@@ -195,14 +176,14 @@ ports {
+ 
+ 			port@0 {
+ 				reg = <0>;
+-				adv7535_in: endpoint {
++				adv7535_in: endpoint@0 {
+ 					remote-endpoint = <&dsi0_out>;
+ 				};
+ 			};
+ 
+ 			port@1 {
+ 				reg = <1>;
+-				adv7535_out: endpoint {
++				adv7535_out: endpoint@1 {
+ 					remote-endpoint = <&hdmi_con_out>;
+ 				};
+ 			};
+@@ -229,27 +210,6 @@ eeprom_carrier: eeprom@57 {
+ 		pagesize = <16>;
+ 	};
+ 
+-
+-	imx219: sensor@10 {
+-		compatible = "sony,imx219";
+-		reg = <0x10>;
+-		clocks = <&imx219_clk>;
+-		clock-names = "extclk";
+-		VANA-supply = <&cam_ext_2v8>;
+-		VDIG-supply = <&cam_ext_1v8>;
+-		VDDL-supply = <&cam_ext_1v2>;
+-		status = "disabled";
+-
+-		port {
+-			imx219_0: endpoint {
+-				remote-endpoint = <&csi2_in>;
+-				clock-lanes = <0>;
+-				data-lanes = <1 2>;
+-				link-frequencies = /bits/ 64 <456000000>;
+-			};
+-		};
+-	};
+-
+ 	ar0521: sensor@36 {
+ 		compatible = "onnn,ar0521";
+ 		reg = <0x36>;
+@@ -270,11 +230,13 @@ ar0521_0: endpoint {
+ };
+ 
+ &ohci0 {
++	spurious-oc;
+ 	dr_mode = "otg";
+ 	status = "okay";
+ };
+ 
+ &ohci1 {
++	spurious-oc;
+ 	status = "okay";
+ };
+ 
+@@ -301,24 +263,6 @@ &scif1 {
+ 	status = "okay";
+ };
+ 
+-/* uSD */
+-&sdhi0 {
+-#if (!SW_SD0_DEV_SEL)
+-	pinctrl-0 = <&sdhi0_pins>;
+-	pinctrl-1 = <&sdhi0_pins_uhs>;
+-	pinctrl-names = "default", "state_uhs";
+-
+-	vmmc-supply = <&reg_sdhi0_vmmc>;
+-	vqmmc-supply = <&reg_sdhi0_vccq>;
+-	sd-uhs-sdr50;
+-	sd-uhs-sdr104;
+-	bus-width = <4>;
+-	max-frequency = <50000000>; /* 50MiB */
+-	status = "disabled";
+-#endif
+-	cd-gpios = <&pinctrl RZG2L_GPIO(47, 0) GPIO_ACTIVE_LOW>;
+-};
+-
+ &spi1 {
+ 	pinctrl-0 = <&spi1_pins>;
+ 	pinctrl-names = "default";
+diff --git a/arch/arm64/boot/dts/renesas/rz_2l-sr-pinfunction.dtsi b/arch/arm64/boot/dts/renesas/rz_2l-sr-pinfunction.dtsi
+index 81591c0d02b3..d3ae2767ded4 100644
+--- a/arch/arm64/boot/dts/renesas/rz_2l-sr-pinfunction.dtsi
++++ b/arch/arm64/boot/dts/renesas/rz_2l-sr-pinfunction.dtsi
+@@ -11,13 +11,25 @@
+ &pinctrl {
+ 	pinctrl-names = "default";
+ 
+-	gpio-sd0-dev-sel-hog {
++	sdhi0_dev_sel_gpio: gpio-sd0-dev-sel-hog {
+ 		gpio-hog;
+ 		gpios = <RZG2L_GPIO(22, 1) GPIO_ACTIVE_HIGH>;
+ 		output-high;
+ 		line-name = "gpio_sd0_dev_sel";
+ 	};
+ 
++	sdhi0_pwr_en_gpio: gpio-sd0-pwr-en-hog {
++		gpio-hog;
++		gpios = <RZG2L_GPIO(4, 1) GPIO_ACTIVE_LOW>;
++		output-high;
++		line-name = "gpio_sd0_pwr_en";
++	};
++
++	can1_pins: can1 {
++		pinmux = <RZG2L_PORT_PINMUX(40, 0, 3)>, /* TxD */
++		<RZG2L_PORT_PINMUX(40, 1, 3)>; /* RxD */
++	};
++
+ 	eth0_pins: eth0 {
+ 		pinmux = <RZG2L_PORT_PINMUX(28, 1, 1)>, /* ET0_LINKSTA */
+ 			<RZG2L_PORT_PINMUX(27, 1, 1)>, /* ET0_MDC */
+@@ -93,6 +105,11 @@ scif1_pins: scif1 {
+ 			 <RZG2L_PORT_PINMUX(41, 1, 1)>; /* RTS# */
+ 	};
+ 
++	scif1_pins_no_hw_flow: scif1_no_hw_flow {
++		pinmux = <RZG2L_PORT_PINMUX(40, 0, 1)>, /* TxD */
++		<RZG2L_PORT_PINMUX(40, 1, 1)>; /* RxD */
++	};
++
+ 	scif2_pins: scif2 {
+ 		pinmux = <RZG2L_PORT_PINMUX(48, 0, 1)>, /* TxD */
+ 			 <RZG2L_PORT_PINMUX(48, 1, 1)>, /* RxD */
+@@ -100,49 +117,60 @@ scif2_pins: scif2 {
+ 			 <RZG2L_PORT_PINMUX(48, 4, 1)>; /* RTS# */
+ 	};
+ 
+-#if SW_SD0_DEV_SEL
+-	sdhi0_emmc_pins: sd0emmc {
+-		sd0_emmc_data {
++	sdhi0_pins: sd0 {
++		sd0_data {
+ 			pins = "SD0_DATA0", "SD0_DATA1", "SD0_DATA2", "SD0_DATA3",
+-				   "SD0_DATA4", "SD0_DATA5", "SD0_DATA6", "SD0_DATA7";
+-			power-source = <1800>;
++			"SD0_DATA4", "SD0_DATA5", "SD0_DATA6", "SD0_DATA7";
++			power-source = <3300>;
+ 		};
+ 
+-		sd0_emmc_ctrl {
++		sd0_ctrl {
+ 			pins = "SD0_CLK", "SD0_CMD";
+-			power-source = <1800>;
++			power-source = <3300>;
+ 		};
+ 
+-		sd0_emmc_rst {
+-			pins = "SD0_RST#";
+-			power-source = <1800>;
++		sd0_cd {
++			pinmux = <RZG2L_PORT_PINMUX(47, 0, 2)>;
+ 		};
+ 	};
+-#else
+-	sdhi0_pins: sd0 {
++
++	sdhi0_pins_uhs: sd0 {
+ 		sd0_data {
+-			pins = "SD0_DATA0", "SD0_DATA1", "SD0_DATA2", "SD0_DATA3";
+-			power-source = <3300>;
++			pins = "SD0_DATA0", "SD0_DATA1", "SD0_DATA2", "SD0_DATA3",
++			"SD0_DATA4", "SD0_DATA5", "SD0_DATA6", "SD0_DATA7";
++			power-source = <1800>;
+ 		};
+ 
+ 		sd0_ctrl {
+ 			pins = "SD0_CLK", "SD0_CMD";
+-			power-source = <3300>;
++			power-source = <1800>;
++		};
++
++		sd0_cd {
++			pinmux = <RZG2L_PORT_PINMUX(47, 0, 2)>;
+ 		};
+ 	};
+ 
+-	sdhi0_pins_uhs: sd0_uhs {
++	sdhi0_pins_1_8_v: sd0_1_8_v {
+ 		sd0_data_uhs {
+-			pins = "SD0_DATA0", "SD0_DATA1", "SD0_DATA2", "SD0_DATA3";
++			pins = "SD0_DATA0", "SD0_DATA1", "SD0_DATA2", "SD0_DATA3",
++			"SD0_DATA4", "SD0_DATA5", "SD0_DATA6", "SD0_DATA7";
+ 			power-source = <1800>;
++			output-impedance-ohms = <33>;
+ 		};
+ 
+ 		sd0_ctrl_uhs {
+ 			pins = "SD0_CLK", "SD0_CMD";
+ 			power-source = <1800>;
++			output-impedance-ohms = <33>;
++		};
++
++		sd0_emmc_rst {
++			pins = "SD0_RST#";
++			power-source = <1800>;
++			output-impedance-ohms = <33>;
+ 		};
+ 	};
+-#endif
+ 
+ 	sdhi1_pins: sd1 {
+ 		sd1_data {
+@@ -156,18 +184,6 @@ sd1_ctrl {
+ 		};
+ 	};
+ 
+-	sdhi1_pins_uhs: sd1_uhs {
+-		sd1_data_uhs {
+-			pins = "SD1_DATA0", "SD1_DATA1", "SD1_DATA2", "SD1_DATA3";
+-			power-source = <1800>;
+-		};
+-
+-		sd1_ctrl_uhs {
+-			pins = "SD1_CLK", "SD1_CMD";
+-			power-source = <1800>;
+-		};
+-	};
+-
+ 	sound_clk_pins: sound_clk {
+ 		pins = "AUDIO_CLK1", "AUDIO_CLK2";
+ 		input-enable;
+@@ -193,9 +209,4 @@ ssi1_pins: ssi1 {
+ 			 <RZG2L_PORT_PINMUX(46, 2, 1)>, /* TXD */
+ 			 <RZG2L_PORT_PINMUX(46, 3, 1)>; /* RXD */
+ 	};
+-
+-    can1_pins: can1 {
+-		pinmux = <RZG2L_PORT_PINMUX(40, 0, 3)>, /* TxD */
+-			<RZG2L_PORT_PINMUX(40, 1, 3)>; /* RxD */
+-	};
+ };
+diff --git a/arch/arm64/boot/dts/renesas/rz_2l-sr-som-common.dtsi b/arch/arm64/boot/dts/renesas/rz_2l-sr-som-common.dtsi
+index da2f444d9fc1..e2e1cbdaf792 100644
+--- a/arch/arm64/boot/dts/renesas/rz_2l-sr-som-common.dtsi
++++ b/arch/arm64/boot/dts/renesas/rz_2l-sr-som-common.dtsi
+@@ -69,12 +69,12 @@ reg_1p1v: regulator-vdd-core {
+ 
+ 	reg_sdhi0_vccq: regulator-vccq-sdhi0 {
+ 		compatible = "regulator-gpio";
+-
+ 		regulator-name = "SDHI0_VCCQ";
+ 		regulator-min-microvolt = <1800000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		states = <3300000 1>, <1800000 0>;
+ 		gpios = <&pinctrl RZG2L_GPIO(39, 0) GPIO_ACTIVE_HIGH>;
++		ramp_delay = <8>;
+ 		regulator-boot-on;
+ 		regulator-always-on;
+ 	};
+@@ -84,14 +84,14 @@ sdio_pwrseq: sdio-pwrseq {
+ 		reset-gpios = <&pinctrl RZG2L_GPIO(23, 1) GPIO_ACTIVE_LOW>;
+ 	};
+ 
+-	x1_clk: x1-clock {
++	x1_clk: xin24m-clock {
+ 		compatible = "fixed-clock";
+ 		#clock-cells = <0>;
+ 		clock-frequency = <24000000>;
+ 	};
+ 
+ 	/* 32.768kHz crystal */
+-	x2_clk: x2-clock {
++	xin32k: xin32k-clock {
+ 		compatible = "fixed-clock";
+ 		#clock-cells = <0>;
+ 		clock-frequency = <32768>;
+@@ -127,6 +127,7 @@ &extal_clk {
+ 
+ &gpu {
+ 	mali-supply = <&reg_1p1v>;
++	memory-region = <&multimedia_cma>;
+ };
+ 
+ &i2c1 {
+@@ -154,9 +155,8 @@ raa215300: raa215300@12 {
+ 		reg = <0x12>, <0x6f>;
+ 		reg-names = "main", "rtc";
+ 
+-		clocks = <&x2_clk>;
++		clocks = <&xin32k>;
+ 		clock-names = "xin";
+-		mpio2-32k-enable;
+ 	};
+ };
+ 
+@@ -194,36 +194,31 @@ &scif2 {
+ 	uart-has-rtscts;
+ 	status = "okay";
+ 
+-	bluetooth {
+-		compatible = "brcm,bcm4330-bt";
++	bluetooth: cyw {
++		max-speed = <460800>;
++		compatible = "brcm,bcm43438-bt";
+ 		shutdown-gpios = <&pinctrl RZG2L_GPIO(23, 0) GPIO_ACTIVE_HIGH>;
+ 	};
+ };
+ 
+-#if SW_SD0_DEV_SEL
+-/* eMMC */
++/* SD/eMMC */
+ &sdhi0 {
+-	pinctrl-0 = <&sdhi0_emmc_pins>;
+-	pinctrl-1 = <&sdhi0_emmc_pins>;
++	pinctrl-0 = <&sdhi0_pins_1_8_v>;
++	pinctrl-1 = <&sdhi0_pins_1_8_v>;
+ 	pinctrl-names = "default", "state_uhs";
+ 
+ 	vmmc-supply = <&reg_3p3v>;
+ 	vqmmc-supply = <&reg_sdhi0_vccq>;
+ 	bus-width = <8>;
+-	mmc-hs200-1_8v;
+-	non-removable;
+-	fixed-emmc-driver-type = <1>;
+ 	status = "okay";
+ };
+-#endif
+ 
+ /* WiFi - CYW43439 */
+ &sdhi1 {
+ 	#address-cells = <1>;
+ 	#size-cells = <0>;
+ 	pinctrl-0 = <&sdhi1_pins>;
+-	pinctrl-1 = <&sdhi1_pins_uhs>;
+-	pinctrl-names = "default", "state_uhs";
++	pinctrl-names = "default";
+ 	status = "okay";
+ 
+ 	non-removable;
+diff --git a/arch/arm64/boot/dts/renesas/rzg2lc-hummingboard.dts b/arch/arm64/boot/dts/renesas/rzg2lc-hummingboard.dts
+index 9432f1bbf08a..008055641c97 100644
+--- a/arch/arm64/boot/dts/renesas/rzg2lc-hummingboard.dts
++++ b/arch/arm64/boot/dts/renesas/rzg2lc-hummingboard.dts
+@@ -8,14 +8,6 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/pinctrl/rzg2l-pinctrl.h>
+ 
+-/*
+- * DIP-Switch S3 setting on SoM
+- * 1 : High; 0: Low
+- * S3[1] : SW_SD0_DEV_SEL	(1: eMMC; 0: uSD)
+- */
+-
+-#define SW_SD0_DEV_SEL	1
+-
+ /dts-v1/;
+ #include "rzg2lc-sr-som.dtsi"
+ #include "rz-hummingboard-common.dtsi"
+@@ -27,8 +19,7 @@ / {
+ 
+ &adv7535 {
+ 	pd-gpios = <&pinctrl RZG2L_GPIO(40, 2) GPIO_ACTIVE_LOW>; // ADV_PD / DSI_EN J9-34 / P40_2
+-	interrupt-parent = <&pinctrl>;
+-	interrupts = <RZG2L_GPIO(42, 2) IRQ_TYPE_EDGE_FALLING>; // DSI_TS_nINT J5001-43
++	interrupts = <RZG2L_GPIO(42, 2) IRQ_TYPE_EDGE_FALLING>;// DSI_TS_nINT J5001-43 P42_2
+ };
+ 
+ &pinctrl {
+@@ -42,10 +33,6 @@ gpio-lte_on {
+ 	};
+ };
+ 
+-&reg_sdhi0_vmmc {
+-	gpio = <&pinctrl RZG2L_GPIO(18, 1) GPIO_ACTIVE_LOW>;
+-};
+-
+ &scif1 {
+ 	pinctrl-0 = <&scif1_pins>;
+ 	pinctrl-names = "default";
+@@ -54,10 +41,6 @@ &scif1 {
+ 	status = "okay";
+ };
+ 
+-&sdhi0 {
+-	cd-gpios = <&pinctrl RZG2L_GPIO(18, 0) GPIO_ACTIVE_LOW>;
+-};
+-
+ &usb0_vbus_otg {
+ 	gpio = <&pinctrl RZG2L_GPIO(4, 0) GPIO_ACTIVE_HIGH>;
+ 	gpio-open-drain;
+diff --git a/arch/arm64/boot/dts/renesas/rzg2lc-sr-som.dtsi b/arch/arm64/boot/dts/renesas/rzg2lc-sr-som.dtsi
+index 2a9ed1130a92..9a8ee6874220 100644
+--- a/arch/arm64/boot/dts/renesas/rzg2lc-sr-som.dtsi
++++ b/arch/arm64/boot/dts/renesas/rzg2lc-sr-som.dtsi
+@@ -83,7 +83,6 @@ &i2c2 {
+ 	pinctrl-0 = <&i2c2_pins>;
+ 	pinctrl-names = "default";
+ 	clock-frequency = <400000>;
+-
+ 	status = "okay";
+ 
+ 	raa215300: raa215300@12 {
+@@ -91,7 +90,7 @@ raa215300: raa215300@12 {
+ 		reg = <0x12>, <0x6f>;
+ 		reg-names = "main", "rtc";
+ 
+-		clocks = <&x2_clk>;
++		clocks = <&xin32k>;
+ 		clock-names = "xin";
+ 		mpio2-32k-enable;
+ 	};
+@@ -128,52 +127,42 @@ scif2_pins: scif2 {
+ 	};
+ };
+ 
+-&reg_sdhi0_vccq {
+-	states = <3300000 0>, <1800000 1>;
+-	gpios = <&pinctrl RZG2L_GPIO(39, 0) GPIO_ACTIVE_LOW>;
++&sdhi0_pins {
++	sd0_cd {
++		pinmux = <RZG2L_PORT_PINMUX(18, 0, 1)>;
++	};
+ };
+ 
+-&sbc {
+-	pinctrl-0 = <&qspi0_pins>;
+-	pinctrl-names = "default";
+-	status = "disabled";
++&sdhi0_pins_uhs {
++	sd0_cd {
++		pinmux = <RZG2L_PORT_PINMUX(18, 0, 1)>;
++	};
+ };
+ 
+-&scif2 {
+-	/delete-property/ dmas;
+-	/delete-property/ dma-names;
++&sdhi0_dev_sel_gpio {
++	gpios = <RZG2L_GPIO(22, 1) GPIO_ACTIVE_LOW>;
++};
+ 
+-	bluetooth {
+-		max-speed = <460800>;
+-		compatible = "brcm,bcm4330-bt";
+-		shutdown-gpios = <&pinctrl RZG2L_GPIO(23, 1) GPIO_ACTIVE_HIGH>;
+-	};
++&sdhi0_pwr_en_gpio {
++	gpios = <RZG2L_GPIO(18, 1) GPIO_ACTIVE_LOW>;
+ };
+ 
+-#if SW_SD0_DEV_SEL
+-/* eMMC */
+-&sdhi0 {
+-	pinctrl-0 = <&sdhi0_emmc_pins>;
+-	pinctrl-1 = <&sdhi0_emmc_pins>;
+-	pinctrl-names = "default", "state_uhs";
+-
+-	vmmc-supply = <&reg_3p3v>;
+-	vqmmc-supply = <&reg_sdhi0_vccq>;
+-	bus-width = <8>;
+-	mmc-hs200-1_8v;
+-	non-removable;
+-	fixed-emmc-driver-type = <1>;
+-	status = "okay";
++&reg_sdhi0_vccq {
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <1800000>;
++	
++	states = <1800000 1>;
++	gpios = <&pinctrl RZG2L_GPIO(39, 0) GPIO_ACTIVE_LOW>;
+ };
+-#endif
+ 
++&sbc {
++	pinctrl-0 = <&qspi0_pins>;
++	pinctrl-names = "default";
++	status = "disabled";
++};
+ 
+-/* WiFi - CYW43439 */
+-&sdhi1 {
+-	brcmf: wifi@1 {
+-		reg = <1>;
+-		compatible = "brcm,bcm4329-fmac";
+-	};
++&bluetooth {
++	shutdown-gpios = <&pinctrl RZG2L_GPIO(23, 1) GPIO_ACTIVE_HIGH>;
+ };
+ 
+ &sdio_pwrseq {
+-- 
+2.46.2
+

--- a/meta-rz-bsp/recipes-kernel/linux/linux-stable/0002-arm64-dts-renesas-Add-overlays-for-SD-and-eMMC-suppo.patch
+++ b/meta-rz-bsp/recipes-kernel/linux/linux-stable/0002-arm64-dts-renesas-Add-overlays-for-SD-and-eMMC-suppo.patch
@@ -1,0 +1,119 @@
+From e1d23180890ed288891b4d00bd32fd56b2c5ee23 Mon Sep 17 00:00:00 2001
+From: Mikhail Anikin <mikhail.anikin@solid-run.com>
+Date: Tue, 8 Oct 2024 18:07:45 +0300
+Subject: [PATCH 2/3] arm64: dts: renesas: Add overlays for SD and eMMC support
+ on HummingBoard
+
+The SolidRun RZ/G2LC HummingBoard supports both SD card and eMMC devices
+on the SDHI0 interface. Previously, the base device tree included
+conditional code to select between SD and eMMC support, which was
+removed to simplify the configuration.
+
+This patch introduces device tree overlays to enable selection
+between SD card and eMMC support without modifying the base device tree.
+
+- Add `rzg2lc-solidrun-mmc-overlay.dtso`:
+  Configures SDHI0 for eMMC support by setting `mmc-hs200-1_8v`,
+  `non-removable`, and `fixed-emmc-driver-type = <1>`. It also sets the
+  `sdhi0_dev_sel_gpio` output to high to select the eMMC device.
+
+- Add `rzg2lc-solidrun-sd-overlay.dtso`:
+  Configures SDHI0 for SD card support by adjusting pin control settings,
+  setting `cap-sd-highspeed` and `bus-width = <4>`, modifying the
+  `reg_sdhi0_vccq` regulator to supply 3.3V, and setting the
+  `sdhi0_dev_sel_gpio` output to low to select the SD card.
+
+Update the Makefile to include the new overlay files in the build process.
+
+These overlays provide flexibility to choose the desired storage option
+at runtime, simplifying device tree maintenance and configuration.
+---
+ arch/arm64/boot/dts/renesas/Makefile          |  2 ++
+ .../renesas/rzg2lc-solidrun-mmc-overlay.dtso  | 20 +++++++++++
+ .../renesas/rzg2lc-solidrun-sd-overlay.dtso   | 34 +++++++++++++++++++
+ 3 files changed, 56 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/renesas/rzg2lc-solidrun-mmc-overlay.dtso
+ create mode 100644 arch/arm64/boot/dts/renesas/rzg2lc-solidrun-sd-overlay.dtso
+
+diff --git a/arch/arm64/boot/dts/renesas/Makefile b/arch/arm64/boot/dts/renesas/Makefile
+index b9b28516b79b..22095a4b2343 100644
+--- a/arch/arm64/boot/dts/renesas/Makefile
++++ b/arch/arm64/boot/dts/renesas/Makefile
+@@ -125,6 +125,8 @@ dtb-$(CONFIG_ARCH_R9A07G044) += r9a07g044l2-smarc-cru-csi-ov5645.dtbo
+ r9a07g044l2-smarc-cru-csi-ov5645-dtbs := r9a07g044l2-smarc.dtb r9a07g044l2-smarc-cru-csi-ov5645.dtbo
+ dtb-$(CONFIG_ARCH_R9A07G044) += r9a07g044l2-smarc-cru-csi-ov5645.dtb
+ dtb-$(CONFIG_ARCH_R9A07G044) += rzg2lc-hummingboard.dtb
++dtb-$(CONFIG_ARCH_R9A07G044) += rzg2lc-solidrun-mmc-overlay.dtbo
++dtb-$(CONFIG_ARCH_R9A07G044) += rzg2lc-solidrun-sd-overlay.dtbo
+ 
+ dtb-$(CONFIG_ARCH_R9A07G054) += r9a07g054l2-smarc.dtb
+ dtb-$(CONFIG_ARCH_R9A07G054) += r9a07g054l2-smarc-cru-csi-ov5645.dtbo
+diff --git a/arch/arm64/boot/dts/renesas/rzg2lc-solidrun-mmc-overlay.dtso b/arch/arm64/boot/dts/renesas/rzg2lc-solidrun-mmc-overlay.dtso
+new file mode 100644
+index 000000000000..d0ca73fda16a
+--- /dev/null
++++ b/arch/arm64/boot/dts/renesas/rzg2lc-solidrun-mmc-overlay.dtso
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    fragment@0 {
++        target = <&sdhi0>;
++        __overlay__ {
++            	mmc-hs200-1_8v;
++            	non-removable;
++            	fixed-emmc-driver-type = <1>;
++        };
++    };
++
++    fragment@1 {
++        target = <&sdhi0_dev_sel_gpio>;
++        __overlay__ {
++            output-high;
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/renesas/rzg2lc-solidrun-sd-overlay.dtso b/arch/arm64/boot/dts/renesas/rzg2lc-solidrun-sd-overlay.dtso
+new file mode 100644
+index 000000000000..2e62ebde7179
+--- /dev/null
++++ b/arch/arm64/boot/dts/renesas/rzg2lc-solidrun-sd-overlay.dtso
+@@ -0,0 +1,34 @@
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pinctrl/rzg2l-pinctrl.h>
++
++/dts-v1/;
++/plugin/;
++
++/ {
++    fragment@0 {
++        target = <&sdhi0>;
++        __overlay__ {
++            pinctrl-0 = <&sdhi0_pins>;
++            pinctrl-names = "default";
++            cap-sd-highspeed;
++            bus-width = <4>;
++        };
++    };
++
++    fragment@1 {
++        target = <&reg_sdhi0_vccq>;
++        __overlay__ {
++            regulator-min-microvolt = <3300000>;
++            regulator-max-microvolt = <3300000>;
++	    states = <3300000 1>;
++	    gpios = <&pinctrl RZG2L_GPIO(39, 0) GPIO_ACTIVE_HIGH>;
++        };
++    };
++
++    fragment@2 {
++        target = <&sdhi0_dev_sel_gpio>;
++        __overlay__ {
++            output-low;
++        };
++    };
++};
+-- 
+2.46.2
+

--- a/meta-rz-bsp/recipes-kernel/linux/linux-stable/0003-arm64-defconfig-Enable-ADIN1100-PHY-driver-in-rz-sol.patch
+++ b/meta-rz-bsp/recipes-kernel/linux/linux-stable/0003-arm64-defconfig-Enable-ADIN1100-PHY-driver-in-rz-sol.patch
@@ -1,0 +1,25 @@
+From f50c286f167afca8e794b3314eb6e95621e89f6b Mon Sep 17 00:00:00 2001
+From: Mikhail Anikin <mikhail.anikin@solid-run.com>
+Date: Tue, 8 Oct 2024 18:08:56 +0300
+Subject: [PATCH 3/3] arm64: defconfig: Enable ADIN1100 PHY driver in
+ rz-solidrun_defconfig
+
+Enable the CONFIG_ADIN1100_PHY option in the rz-solidrun_defconfig to
+provide support for the ADIN1100 Ethernet PHY used on the RZ/G2LC
+HummingBoard.
+---
+ arch/arm64/configs/rz-solidrun_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/configs/rz-solidrun_defconfig b/arch/arm64/configs/rz-solidrun_defconfig
+index eac532925840..fab209d4fff8 100644
+--- a/arch/arm64/configs/rz-solidrun_defconfig
++++ b/arch/arm64/configs/rz-solidrun_defconfig
+@@ -833,3 +833,4 @@ CONFIG_DEBUG_FS=y
+ # CONFIG_SCHED_DEBUG is not set
+ # CONFIG_FTRACE is not set
+ CONFIG_REGULATOR_RAA215300=y
++CONFIG_ADIN1100_PHY=y
+-- 
+2.46.2
+

--- a/meta-rz-bsp/recipes-kernel/linux/linux-stable_6.9.bb
+++ b/meta-rz-bsp/recipes-kernel/linux/linux-stable_6.9.bb
@@ -2,10 +2,16 @@ DESCRIPTION = "Linux stable kernel"
 
 require linux.inc
 
-KBRANCH = "linux-6.9.y-renesas"
-SRCREV = "b51a1e80e7ac3923dcbd14194b9fc4f4ebb7e58b"
-SRC_URI = "https://github.com/amotus/linux-renesas;protocol=https;branch=${KBRANCH}"
+KBRANCH = "linux-6.9.y-solidrun"
+SRCREV = "f9315e3bfccb1c3c8288b452450ed3ddcc3be7cb"
+SRC_URI = "git://github.com/amotus/linux-renesas;protocol=https;branch=${KBRANCH}"
 
-LINUX_VERSION = "6.9.5"
+SRC_URI:append = " \
+    file://0001-arm64-dts-renesas-Cleanup-HummingBoard-RZG2LC-Device.patch \
+    file://0002-arm64-dts-renesas-Add-overlays-for-SD-and-eMMC-suppo.patch \
+    file://0003-arm64-defconfig-Enable-ADIN1100-PHY-driver-in-rz-sol.patch \
+"
+
+LINUX_VERSION = "6.9.7"
 
 COMPATIBLE_MACHINE = "(rzg2h-family|rzg2l-family)"


### PR DESCRIPTION
This pull request updates the Yocto recipes and machine configurations for the SolidRun RZ/G2LC HummingBoard 

- [u-boot] Update u-boot to cip41
- [linux] Cleanup device trees
- [linux] Add SD/eMMC overlays
- [linux-firmware] Add missing symlinks and bluetooth firmware
- [yocto] Update solidrun-rzg2lc-hummingboard machine to include overlays, missing kernel modules, etc